### PR TITLE
Removed erroneous capital "O" in "or"

### DIFF
--- a/source/linux/mail/mailconfig.md
+++ b/source/linux/mail/mailconfig.md
@@ -36,7 +36,7 @@ From a mail client you would use the A record you have set up to connect, so in 
 
 If you wanted to use an external service to send mail also, you would need to add the IP range of that mail service, usually they will provide a single DNS records or IP range for you to include. It is recommended that you consult their documentation for this purpose as it will be specialised for their service.
 
-You will also need to setup a hostname for the server which matches the reverse DNS. In our example this would be mail.ukfast.co.uk. You can learn how to change your hostname [HERE](../misc/hostname.html).
+You will also need to setup a hostname for the server which matches the reverse DNS. In our example this would be mail.ukfast.co.uk. You can learn how to change your hostname [here](../misc/hostname.html).
  
 ## Misc Issues
 ### Blacklists
@@ -49,7 +49,7 @@ Please note that most blacklists use DNS and have a TTL. This is the number of s
 
 ### Microsoft/Hotmail/Office365
 
-Microsoft mail servers are a little different to other providers. Their blacklists are not public so you cannot check if you are blacklisted and you must always get an IP address (Or range) whitelisted if you want the mail to end up in the correct mailbox, if it is not it will always be sent to spam. This is described as a "greylist".
+Microsoft mail servers are a little different to other providers. Their blacklists are not public so you cannot check if you are blacklisted and you must always get an IP address (or range) whitelisted if you want the mail to end up in the correct mailbox, if it is not it will always be sent to spam. This is described as a "greylist".
 
 In terms of preparing for getting whitelisted by Microsoft, you must follow the steps previously in this documentation page. The two important factors are setting up SPF records and having a hostname on the server resolve to what the rDNS is for the IP sending the mail from that server.
 
@@ -60,6 +60,6 @@ The first step is to sign up to the JMRP and SNDS services which are provided by
 
 You should also submit an outlook.com sender information form [here](https://support.live.com/eform.aspx?productKey=edfsmsbl3&ct=eformts&wa=wsignin1.0&scrx=1).
 
-Once you have completed those steps you will need to email microsoft to greylist your IP (Or range) at delist@messaging.microsoft.com. Office365 also has a delist page [here](https://sender.office.com/).
+Once you have completed those steps you will need to email microsoft to greylist your IP (or range) at delist@messaging.microsoft.com. Office365 also has a delist page [here](https://sender.office.com/).
 
 The process can take up to a week, however it usually is done in under 24 hours.


### PR DESCRIPTION
two examples where "Or" is used as opposed to "or" (unless there's a reason I'm not aware of)

removed use of all caps in "HERE" and replaced with "here"