### PR TITLE
Change of page order

### DIFF
--- a/source/linux/mail/index.rst
+++ b/source/linux/mail/index.rst
@@ -5,7 +5,7 @@ Mail
 .. toctree::
    :maxdepth: 1
 
+   mailconfig
    bounces
    exim
-   mailconfig
    postfix


### PR DESCRIPTION
moving "Basics of mail" (previously "Mail Primer") to the top of the list.  It makes sense to put this article first.