### PR TITLE
Adding /index to each page in index file

### DIFF
--- a/source/FASTcloudbackup/index.rst
+++ b/source/FASTcloudbackup/index.rst
@@ -7,12 +7,12 @@ FASTcloudbackup allows you to backup the files and folders on laptops, desktop c
 .. toctree::
    :maxdepth: 1
    
-   General product information
-   Gettingstarted
-   InstallingtheFASTcloudbackupagent
-   Settingupbackups
-   Managingfilesandfolders
-   Restoringfilesandfoldersfromabackup
-   alerts
-   ManagingFASTcloudbackup
-   Troubleshooting
+   General product information/index
+   Gettingstarted/index
+   InstallingtheFASTcloudbackupagent/index
+   Settingupbackups/index
+   Managingfilesandfolders/index
+   Restoringfilesandfoldersfromabackup/index
+   alerts/index
+   ManagingFASTcloudbackup/index
+   Troubleshooting/index


### PR DESCRIPTION
The FASTcloudbackup option does not appear in the Categories side navigation menu on most pages on docs.  Thought this might be because I didn't put /index after each page name in the FASTcloudbackup index file?