### PR TITLE
Added test for markdown to contain meta info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 - pip install Sphinx
 - pip install recommonmark
 script:
+- ./tests.sh
 - sphinx-build -nW -b html -d build/doctrees source/ build/html
 - make build/html/_static/css/app.css
 - make build/html/_static/app.js

--- a/source/cloud/vault/connecting.md
+++ b/source/cloud/vault/connecting.md
@@ -1,3 +1,9 @@
+```eval_rst
+.. meta::
+   :title: UKFast Documentation | eCloud Vault | Connecting to eCloud Vault
+   :description: Detailed information on ways to connect to UKFast's eCloud Vault
+```
+
 # Connecting to eCloud Vault
 
 There are 2 primary means of interacting with eCloud Vault.

--- a/source/cloud/vault/s3website.md
+++ b/source/cloud/vault/s3website.md
@@ -1,3 +1,8 @@
+```eval_rst
+.. meta::
+   :title: UKFast Documentation | eCloud Vault | Basic s3website API usage
+   :description: Information on how you can host a static website on eCloud vault using the S3website interface
+```
 # Basic s3website API usage
 
 ```eval_rst
@@ -7,9 +12,9 @@
   If you're not using this method of authentication, you may need to specify additional flags/options in the commands used in this article.
 ```
 
-You can host a static website on Valut using the S3website interface.
+You can host a static website on eCloud vault using the S3website interface.
 
-## Hosting a Static Website on Ecloud Vault
+## Hosting a Static Website on eCloud Vault
 
 Start by creating a bucket using the domain name you wish to use such as:
 

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script will do a simple check for meta information in changed *.md files
+
+file_names=`(git diff --name-only $TRAVIS_COMMIT_RANGE || echo "") | tr '\n' ' '`
+
+for f in $file_names; do
+  if [ ! -f "$f" ]; then
+    echo "$f : Is not a file or does not exist anymore."
+    continue
+  fi
+  case $f in
+    *.md )
+    meta=$(grep '\.\. meta::' $f >> /dev/null 2>&1; echo $?)
+    if [[ "$meta" != "0" ]]; then
+      echo "$f : Does not contain meta info"
+      fail=1
+    fi
+  esac
+done
+
+if [[ "$fail" == "1" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
@garryprior @darrentayloruk 

Hi Both,

This is how to add meta info to markdown when we run it through Sphinx. I've also added a basic test that will check for the existance of meta info in any changed markdown files so ones created / edited from this moment will need to have the correct info.