### PR TITLE
adding a new page that exposes ddosx ips

### DIFF
--- a/source/1
+++ b/source/1
@@ -1,1 +1,0 @@
-grep: 2: No such file or directory

--- a/source/network/cdn/managingcdn.md
+++ b/source/network/cdn/managingcdn.md
@@ -28,6 +28,8 @@ This allows for the client to ignore response headers that relate to caching:
 * Expires 
 * X-Accel-Expires
 
+So you will see the header still in the response header, but the CDN will be setting it's own length to the cache content to what has been set in [ddos](https://my.ukfast.co.uk/ddosx)
+
 If there is a set-cookie in the header we won't cache this even if Custom has been configured in https://my.ukfast.co.uk/ddosx
 
 ## Special Cases

--- a/source/network/cdn/managingcdn.md
+++ b/source/network/cdn/managingcdn.md
@@ -7,6 +7,9 @@ To ensure your content is cached:
 * The type of request must be a GET or HEAD request
 * The http response must be 200, 301 or 206 if you are setting how long content is cached by the CDN, otherwise we will respect the Cache-Control header.
 
+### Respect Origin Cache Control headers
+Essentially the CDN determines what should be cached based on backend Cache-Control headers.
+
 There are also a number of reasons why content will not cached:
 
 * There is a nocache cookie (Cache-Control: no-cache=Set-Cookie)
@@ -15,6 +18,17 @@ There are also a number of reasons why content will not cached:
 * A nocache argument has been added to the request. (For example example.org/?nocache=true)
 * The Authorization http header is present in the request
 * The purge http header is present. This is not a standard header and is more likely to be used if you want to force the CDN server to fetch from the origin server (purge: something)
+* If respect Origin Cache Control headers is configured, but not Cache-Control header is seen in the response, this will not be cached. 
+* Special Vary: * header has been configured in the backend response headers.
+
+### Custom
+This allows for the client to ignore response headers that relate to caching:
+
+* Cache-Control 
+* Expires 
+* X-Accel-Expires
+
+If there is a set-cookie in the header we won't cache this even if Custom has been configured in https://my.ukfast.co.uk/ddosx
 
 ## Special Cases
 

--- a/source/network/cdn/troubleshooting.md
+++ b/source/network/cdn/troubleshooting.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+## Why am I getting a X-Proxy-Cache: MISS
+
+If you have configured Respect Origin Cache-Control headers in [ddosx] (https://my.ukfast.co.uk/ddosx), you need to make sure that you have Cache-Control headers set and to something that doesn't fall under the catagory of not cacheable as per [manage cdn] (https://docs.ukfast.co.uk/network/cdn/managingcdn.html#caching-content)
+
+The distributed nature of the servers in each pop has a trade off that means cache is stored locally at each server, so you might find requests with a HIT will next return a MISS, this is entirely possible until the cache has been stored by each server.
+
+If you have configured Custom there are two cases where you might get a MISS, this is if in the response header there is a `Set-Cookie` or the special `Vary: *` header has been set. The reason behind this is caching content with `Set-Cookie` if mis configured might lead to content that is supposed to be user specific from being cached for another user. Also the Vary header if ignored could mean that content that is meant to be cached differently from others might not be.
+
+For example if the `Vary: Accept-Encoding` header is sent in the response, this tells the CDN that compressed and none compressed content should be cached independantly. If we ignore this header this could leave to compressed content being cached and delivered cache to clients that haven't sent Accept-Encoding in the request headers to get back compressed content.
+
+Please make sure that the Content-Type matches the mime-types that have been selected in my.ukfast.co.uk/ddosx/. You can do this using curl and request the content with a HEAD request:
+curl -I example.org/image.png
+
+and confirm the Content-Type header that is returned matches the mime type that has been configured.

--- a/source/network/cdn/troubleshooting.md
+++ b/source/network/cdn/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Why am I getting a X-Proxy-Cache: MISS
 
-If you have configured Respect Origin Cache-Control headers in [ddosx](https://my.ukfast.co.uk/ddosx), you need to make sure that you have Cache-Control headers set and to something that doesn't fall under the catagory of not cacheable as per [manage cdn](https://docs.ukfast.co.uk/network/cdn/managingcdn.html#caching-content)
+If you have configured Respect Origin Cache-Control headers in [DDoSX](https://my.ukfast.co.uk/ddosx), you need to make sure that you have Cache-Control headers set and to something that doesn't fall under the catagory of not cacheable as per [manage cdn](https://docs.ukfast.co.uk/network/cdn/managingcdn.html#caching-content)
 
 The distributed nature of the servers in each pop has a trade off that means cache is stored locally at each server, so you might find requests with a HIT will next return a MISS, this is entirely possible until the cache has been stored by each server.
 
@@ -10,7 +10,7 @@ If you have configured Custom there are two cases where you might get a MISS, th
 
 For example if the `Vary: Accept-Encoding` header is sent in the response, this tells the CDN that compressed and none compressed content should be cached independantly. If we ignore this header this could leave to compressed content being cached and delivered cache to clients that haven't sent Accept-Encoding in the request headers to get back compressed content.
 
-Please make sure that the Content-Type matches the mime-types that have been selected in [ddosx](https://my.ukfast.co.uk/ddosx/). You can do this using curl and request the content with a HEAD request:
+Please make sure that the Content-Type matches the mime-types that have been selected in [DDoSX](https://my.ukfast.co.uk/ddosx/). You can do this using curl and request the content with a HEAD request:
 curl -I example.org/image.png
 
 and confirm the Content-Type header that is returned matches the mime type that has been configured.

--- a/source/network/cdn/troubleshooting.md
+++ b/source/network/cdn/troubleshooting.md
@@ -10,7 +10,8 @@ If you have configured Custom there are two cases where you might get a MISS, th
 
 For example if the `Vary: Accept-Encoding` header is sent in the response, this tells the CDN that compressed and none compressed content should be cached independantly. If we ignore this header this could leave to compressed content being cached and delivered cache to clients that haven't sent Accept-Encoding in the request headers to get back compressed content.
 
-Please make sure that the Content-Type matches the mime-types that have been selected in [DDoSX](https://my.ukfast.co.uk/ddosx/). You can do this using curl and request the content with a HEAD request:
-curl -I example.org/image.png
+Please make sure that the Content-Type matches the mime-types that have been selected in [DDoSX](https://my.ukfast.co.uk/ddosx/). You can do this using curl and request the content with a `HEAD` request:
 
-and confirm the Content-Type header that is returned matches the mime type that has been configured.
+`curl -I example.org/image.png`
+
+and confirm the `Content-Type` header that is returned matches the mime type that has been configured.

--- a/source/network/cdn/troubleshooting.md
+++ b/source/network/cdn/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Why am I getting a X-Proxy-Cache: MISS
 
-If you have configured Respect Origin Cache-Control headers in [ddosx] (https://my.ukfast.co.uk/ddosx), you need to make sure that you have Cache-Control headers set and to something that doesn't fall under the catagory of not cacheable as per [manage cdn] (https://docs.ukfast.co.uk/network/cdn/managingcdn.html#caching-content)
+If you have configured Respect Origin Cache-Control headers in [ddosx](https://my.ukfast.co.uk/ddosx), you need to make sure that you have Cache-Control headers set and to something that doesn't fall under the catagory of not cacheable as per [manage cdn](https://docs.ukfast.co.uk/network/cdn/managingcdn.html#caching-content)
 
 The distributed nature of the servers in each pop has a trade off that means cache is stored locally at each server, so you might find requests with a HIT will next return a MISS, this is entirely possible until the cache has been stored by each server.
 
@@ -10,7 +10,7 @@ If you have configured Custom there are two cases where you might get a MISS, th
 
 For example if the `Vary: Accept-Encoding` header is sent in the response, this tells the CDN that compressed and none compressed content should be cached independantly. If we ignore this header this could leave to compressed content being cached and delivered cache to clients that haven't sent Accept-Encoding in the request headers to get back compressed content.
 
-Please make sure that the Content-Type matches the mime-types that have been selected in my.ukfast.co.uk/ddosx/. You can do this using curl and request the content with a HEAD request:
+Please make sure that the Content-Type matches the mime-types that have been selected in [ddosx](https://my.ukfast.co.uk/ddosx/). You can do this using curl and request the content with a HEAD request:
 curl -I example.org/image.png
 
 and confirm the Content-Type header that is returned matches the mime type that has been configured.

--- a/source/security/ddos/index.rst
+++ b/source/security/ddos/index.rst
@@ -11,3 +11,4 @@ DDoSX\ :sup:`®` is designed to protect your websites and applications from Deni
    gettingstarted
    remove
    troubleshooting
+   ips

--- a/source/security/ddos/ips
+++ b/source/security/ddos/ips
@@ -1,0 +1,20 @@
+IP Ranges
+
+For some applications you may want to know the IP Ranges that are used on the DDoSX platform (e.g. such as set_real_ip feature of nginx.)
+
+IPv4: 
+Unicast Range:
+185.156.64.0/24
+23.170.128.0/24
+
+Anycast Range:
+185.181.196.0/22
+
+
+IPv6:
+Unicast Range:
+2a02:21a8:1::/48
+2a02:21a8:2::/48
+
+Anycast Range:
+2a02:21a8::/48

--- a/source/security/ddos/ips
+++ b/source/security/ddos/ips
@@ -1,20 +1,20 @@
-IP Ranges
+# IP Ranges
 
-For some applications you may want to know the IP Ranges that are used on the DDoSX platform (e.g. such as set_real_ip feature of nginx.)
+For some applications you may want to know the IP Ranges that are used on the DDoSX<sup>®</sup> platform (e.g. such as set_real_ip feature of nginx.)
 
-IPv4: 
-Unicast Range:
-185.156.64.0/24
-23.170.128.0/24
+## IPv4: 
+### Unicast Range:
+* 185.156.64.0/24
+* 23.170.128.0/24
 
-Anycast Range:
-185.181.196.0/22
+### Anycast Range:
+* 185.181.196.0/22
 
 
-IPv6:
-Unicast Range:
-2a02:21a8:1::/48
-2a02:21a8:2::/48
+## IPv6:
+### Unicast Range:
+* 2a02:21a8:1::/48
+* 2a02:21a8:2::/48
 
-Anycast Range:
-2a02:21a8::/48
+### Anycast Range:
+* 2a02:21a8::/48


### PR DESCRIPTION
This can be used a public facing page with IPs that clients applications might find useful, and we link to it if new pops are added, etc.