### PR TITLE
Add a note about s3cmd 1.6.1 configuration option

### DIFF
--- a/source/cloud/vault/connecting.md
+++ b/source/cloud/vault/connecting.md
@@ -27,12 +27,14 @@ If you aren't familiar with the S3 API specification, information can be found h
 Your keypair will also allow you to access your buckets through various s3 enabled third party applications. Though UKFast can't offer any support on these applications (see below), a few are mentioned below:
 
 * [Cyberduck]     - Windows, Mac
-* [s3cmd]        - Windows, Linux and Mac CLI tool
+* [s3cmd]        - Windows, Linux and Mac CLI tool (see note below)
 * [Duplicati]    - Windows backup utility
 * [Expandrive]    - Windows s3 drive utility
 * [S3Anywhere]    - Android s3 client
 
 Configuration and use of these aren't supported by UKFast, but they can typically all be configured by setting the s3 host/address as ``vault.ecloud.co.uk`` and inputting your access and secret keys.
+
+Please note that for `s3cmd` version 1.6.1 or above, you will need to add `signature_v2 = True` to your `.s3cfg` configuration file or you may encounter `SignatureDoesNotMatch` errors when uploading files with spaces in the filename.
 
 UKFast will take all necessary steps to ensure that your data on our systems remains accessible, that data integrity is maintained and the API remains accessible. Beyond this, UKFast take no responsibility for your use of this system. We are not able to offer support for any 3rd-party product, nor the use of the Ceph API in your own applications.
 


### PR DESCRIPTION
s3cmd 1.6.1 and above changes the default signature method which isn't compatible with Vault when uploading files with spaces in the filename.