### PR TITLE
reStructureText directives must have two colons

### DIFF
--- a/source/cloud/vault/connecting.md
+++ b/source/cloud/vault/connecting.md
@@ -1,5 +1,5 @@
 ```eval_rst
-.. title: UKFast Documentation | eCloud Vault | Connecting to eCloud Vault
+.. title:: UKFast Documentation | eCloud Vault | Connecting to eCloud Vault
 .. meta::
    :title: UKFast Documentation | eCloud Vault | Connecting to eCloud Vault
    :description: Detailed information on ways to connect to UKFast's eCloud Vault


### PR DESCRIPTION
Syntax for rst directives is to use two colons.

This is related to #197