### PR TITLE
Make deploy_docs.sh check resolvers first and abort on error

### DIFF
--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+set -e
+if ! getent hosts github.com > /dev/null 2>&1; then
+    /usr/bin/logger -s -t deploy_docs 'Failed to resolve github.com, aborting deployment'
+    exit 1
+fi
 cd /opt/docs.ukfast.co.uk
 git submodule update --init
 git pull --recurse-submodules origin master


### PR DESCRIPTION
Two changes here - the first is to add `set -e` to the deploy_docs.sh
script which will abort the script if an error is encountered at any
point during execution. This should hopefully prevent any half-complete
deployments.

Second is to check that github.com resolves before doing anything. If it
can't be resolved it'll bail out and add a message to the system log.