### PR TITLE
Modified flex v6 docs to reflect actual configuration options

### DIFF
--- a/source/cloud/flex/ipv6.md
+++ b/source/cloud/flex/ipv6.md
@@ -26,7 +26,7 @@ If your eCloud Flex account does not currently have IPv6, you can enable it by f
 
     ![subnet](files/subnet.PNG)
 
-6. On the next tab you customise any settings (such as using SLAAC which is available in the IPv6 Address Configuration Mode drop-down menu), but by default you'll be given DHCPv6.  Click `Create`
+6. On the next tab you customise any settings. You must select an option in the IPv6 Address Configuration Mode drop-down menu (such as SLAAC or DHCPv6).  Click `Create`
 
 7. Once created, you will be given a public IPv6 /64 prefix, which will appear in your Networks list, as shown below.  
 
@@ -43,6 +43,11 @@ If your eCloud Flex account does not currently have IPv6, you can enable it by f
     ![interface](files/interface.PNG)
 
 You will now see an IPv6 address is allocated to your router's interface, as shown below - this should now respond to ICMP if you have an existing IPv6 network to test it from.
+
+```eval_rst
+.. warning::
+  Warning: UKFast only support IPv6 in a dual stack configuration. If you choose to use an IPv6 only network be aware cloud-init will only work if you use the config-drive option on instance deployment.
+```
 
 ![newinterface](files/newinterface.PNG)
 

--- a/source/cloud/flex/ipv6.md
+++ b/source/cloud/flex/ipv6.md
@@ -46,7 +46,7 @@ You will now see an IPv6 address is allocated to your router's interface, as sho
 
 ```eval_rst
 .. warning::
-  Warning: UKFast only support IPv6 in a dual stack configuration. If you choose to use an IPv6 only network be aware cloud-init will only work if you use the config-drive option on instance deployment.
+  Warning: When using SLAAC, UKFast can only support IPv6 usage in a dual stack configuration, due to limited IPv6 support with certain images. If you choose to use an IPv6 only network be aware cloud-init will only work if you use the config-drive option on instance deployment.
 ```
 
 ![newinterface](files/newinterface.PNG)

--- a/source/cloud/flex/ipv6.md
+++ b/source/cloud/flex/ipv6.md
@@ -46,7 +46,7 @@ You will now see an IPv6 address is allocated to your router's interface, as sho
 
 ```eval_rst
 .. warning::
-  Warning: When using SLAAC, UKFast can only support IPv6 usage in a dual stack configuration, due to limited IPv6 support with certain images. If you choose to use an IPv6 only network be aware cloud-init will only work if you use the config-drive option on instance deployment.
+  Warning: When using SLAAC, UKFast can only support IPv6 usage in a dual stack configuration, due to limited IPv6 support with certain images. We only support DNS configuration in IPv4 subnets. If you choose to use an IPv6 only network be aware cloud-init will only work if you use the config-drive option on instance deployment.
 ```
 
 ![newinterface](files/newinterface.PNG)


### PR DESCRIPTION
DHCPv6 is not selected by default, and a configuration mode has to be selected for IPv6 to work correctly. Also added warning about IPv6-only networks having problems with cloud-init, config-drive must be used.