### PR TITLE
Updating memory limit to the recommended value

### DIFF
--- a/source/operatingsystems/linux/magento/magento2/php/php.md
+++ b/source/operatingsystems/linux/magento/magento2/php/php.md
@@ -107,7 +107,7 @@ Review and copy the settings from /root/php_upgrade_backup-$(date +%d_%b_%Y)/php
 cp /etc/php.ini /root/php.ini.default
 sed -ie "s_;date.timezone =_date.timezone = \"Europe/London\"_g" /etc/php.ini
 sed -ie "s/; max_input_vars = 1000/max_input_vars = 20000/g" /etc/php.ini
-sed -ie "s/memory_limit = 128M/memory_limit = 756M/" /etc/php.ini
+sed -ie "s/memory_limit = 128M/memory_limit = 2G/" /etc/php.ini
 sed -ie "s/max_execution_time = 30/max_execution_time = 18000/" /etc/php.ini
 sed -ie "s/max_input_time = 60/max_input_time = 90/" /etc/php.ini
 sed -ie "s/short_open_tag = Off/short_open_tag = On/" /etc/php.ini


### PR DESCRIPTION
The memory limit especially should be at a minimum of 2GB for Magento 2 "normal use and debugging" documented here: https://devdocs.magento.com/guides/v2.3/install-gde/trouble/php/tshoot_php-set.html