### PR TITLE
Fixed Unordered List Spacing

### DIFF
--- a/source/_themes/ukf/static/css/style.css
+++ b/source/_themes/ukf/static/css/style.css
@@ -78,6 +78,13 @@ p {
     margin: 0 0 20px;
 }
 
+/* 
+Sphinx now adds a paragraph to unordered lists,
+creating some annoying spacing.
+https://stackoverflow.com/questions/49700502/inconsistent-line-spacing-in-restructuredtext-document
+This change should fix that without making changes to the sphinx source or downgrading the html renderer to v4.
+*/
+.simple > li > p { margin: 0 0 -5px } 
 
 
 /* Preformatted text */


### PR DESCRIPTION
Sphinx has changed how it renders unordered lists in between the old version we were on and the latest one that we're on now.

Now it adds a paragraph tag inside each entry causing unnecessary spacing.

https://stackoverflow.com/questions/49700502/inconsistent-line-spacing-in-restructuredtext-document

Updated the css to target it and reduce the spacing.

https://img.lee.io/c0eed7e9-9fa0-4820-a8cc-ed386d8b27ac.png