### PR TITLE
Update footer year & remove Google+ link

### DIFF
--- a/source/_themes/ukf/layout.html
+++ b/source/_themes/ukf/layout.html
@@ -282,7 +282,6 @@
 			<div class="col-xs-12 col-sm-12 col-md-12 social-footer text-center ">
 				<a href="https://twitter.com/UKFast" data-toggle="tooltip" title="Twitter"><i class="fa icon-social fa-twitter"></i></a>
 				<a href="https://www.facebook.com/UKFast.co.uk" data-toggle="tooltip" title="Facebook"><i class="fa icon-social fa-facebook"></i></a>
-				<a href="https://plus.google.com/+ukfast/posts" data-toggle="tooltip" title="Google Plus"><i class="fa icon-social  fa-google-plus"></i></a>
 				<a href="https://www.youtube.com/user/UKFast" data-toggle="tooltip" title="Youtube"><i class="fa icon-social fa-youtube-play"></i></a>
 				<a href="https://www.linkedin.com/company/ukfast-ukfast-net-limited-" data-toggle="tooltip" title="LinkedIn"><i class="fa icon-social fa-linkedin"></i></a>
 				<a href="https://www.ukfast.co.uk/press-releases/feed.rss" data-toggle="tooltip" title="RSS"><i class="fa icon-social fa-rss"></i></a>
@@ -342,7 +341,7 @@
 		<div class="row">
 			<div class="col-md-12 text-center mt30">
 				<p class="copyright">
-					© UKFast.Net Ltd 1999 - 2019 UK's Best Dedicated Server Web Hosting | <a href="https://www.ukfast.co.uk/terms.html?tab=privacypolicy&#setupoption">Privacy Policy</a> | <a href="https://www.ukfast.co.uk/support.html">Support</a> | <a href="https://www.ukfast.co.uk/corporate-guidance.html">Corporate Guidance</a> | <a href="https://www.ukfast.co.uk/sitemap.html">Sitemap</a><br>UKFast.Net Limited, Registered in England, Company Registration Number 03845616, Registered Office: UKFast Campus, Birley Fields, Manchester, England, M15 5QJ
+					© UKFast.Net Ltd 1999 - <script>document.write(new Date().getFullYear())</script> UK's Best Dedicated Server Web Hosting | <a href="https://www.ukfast.co.uk/terms.html?tab=privacypolicy&#setupoption">Privacy Policy</a> | <a href="https://www.ukfast.co.uk/support.html">Support</a> | <a href="https://www.ukfast.co.uk/corporate-guidance.html">Corporate Guidance</a> | <a href="https://www.ukfast.co.uk/sitemap.html">Sitemap</a><br>UKFast.Net Limited, Registered in England, Company Registration Number 03845616, Registered Office: UKFast Campus, Birley Fields, Manchester, England, M15 5QJ
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Google+ link is dead now and I've swapped the footer copyright year to be JS driven so it'll always be up to date.