### PR TITLE
Updated the populator to sanitise text going into ElasticSearch better

### DIFF
--- a/populator/main.py
+++ b/populator/main.py
@@ -125,8 +125,7 @@ def approximate_meta(text):
             if not title:
                 title = ''.join(ch for ch in line if ch.isalnum() or ch == ' ')
                 continue
-            if not description and line.startswith('#') is False and line.startswith('..') is False and line.startswith(
-                    '``') is False:
+            if not description and not line.startswith('#') and not line.startswith('..') and not line.startswith('``'):
                 description = line
                 break
 

--- a/populator/main.py
+++ b/populator/main.py
@@ -71,7 +71,6 @@ def prettify(text):
                 safe = False
                 break
         if safe:
-            # output += " ".join(line.split())
             output += line + ' '
 
     return output

--- a/populator/main.py
+++ b/populator/main.py
@@ -71,8 +71,8 @@ def prettify(text):
                 safe = False
                 break
         if safe:
-            output += " ".join(line.split())
-            # output += line.replace('\n', ' ')
+            # output += " ".join(line.split())
+            output += line + ' '
 
     return output
 

--- a/populator/main.py
+++ b/populator/main.py
@@ -71,7 +71,8 @@ def prettify(text):
                 safe = False
                 break
         if safe:
-            output += line.replace('\n', '')
+            output += " ".join(line.split())
+            # output += line.replace('\n', ' ')
 
     return output
 

--- a/source/ecloud/private/cloning-and-templating-vms.md
+++ b/source/ecloud/private/cloning-and-templating-vms.md
@@ -3,7 +3,6 @@
 ```eval_rst
 
    .. title:: eCloud Private | Cloning and Templating VMs
-
    .. meta::
       :title: eCloud Private | Cloning and Templating VMs | UKFast Documentation
       :description: Information on how to clone and template VMs in your eCloud Private solution

--- a/source/ecloud/private/cloning-and-templating-vms.md
+++ b/source/ecloud/private/cloning-and-templating-vms.md
@@ -6,7 +6,7 @@
 
    .. meta::
       :title: eCloud Private | Cloning and Templating VMs | UKFast Documentation
-      :description: Information on how to Cloning and Templating VMs in your eCloud Private solution
+      :description: Information on how to clone and template VMs in your eCloud Private solution
 
 ```
 


### PR DESCRIPTION
Populator now removes all newline characters from elastic search 'content' (does not touch titles, descriptions or keywords. Just the body text used for providing relevant search results.)
This solves the bug where search results seemingly only showed the title of a result, and not the description, as the description text was prepended with some newline chars.