### PR TITLE
Extract the current pages navigation text from the TOC 

### DIFF
--- a/source/_themes/ukf/layout.html
+++ b/source/_themes/ukf/layout.html
@@ -62,7 +62,7 @@
     <link rel="top" title="{{ docstitle|e }}" href="{{ pathto('index') }}" />
     {%- if parents %}
     <link rel="up" title="{{ parents[-1].title|striptags|e }}" href="{{ parents[-1].link|e }}" />
-    {%- endif %}
+	{%- endif %}
     {%- if next %}
     <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e }}" />
     {%- endif %}
@@ -219,7 +219,11 @@
 
 <div class="row">
 
-  {## Grid layout on root index only ##}
+	{# toctree contains the site nav - we'll use to extract the navigation title for the final breadcrumb - can't find another way! #}
+	{% set theTocTree = toctree() | replace("</a>", ";") | replace(" href=\"", "></a>") | striptags | replace("\">", "%") %}
+    {% set theTocTree = theTocTree.split(";") %}
+
+	{## Grid layout on root index only ##}
   {%- if pagename == 'index' -%}
 
   <div id="main-menu-container" class="container">
@@ -269,6 +273,19 @@
 		</ul>
 	</div>
 	<div class="grid-item box">
+		<i class="fa fa-envelope-o"></i>
+		<h2><a href="/email/">Email</a></h2>
+		<ul>
+			<li><a href="/email/mailconfig.html">Basic Email Config</a></li>
+			<li><a href="/desktop/sharedexchange/index.html">Shared Exchange</a></li>
+			<li><a href="/email/bounces.html">Legitimate Mail Being Blocked/Bouncing</a></li>
+			<li><a href="/email/dkim.html">DomainKeys Identified Mail (DKIM)</a></li>
+			<li><a href="/email/spf.html">Sender Policy Framework (SPF) records</a></li>
+			<li><a href="/email/postfix.html">Postfix mail transfer agent</a></li>
+			<li><a href="/email/hmail-antispam-setup.html">hMailServer - Anti-spam Setup</a></li>
+		</ul>
+	</div>
+	<div class="grid-item box col2">
 		<i class="fa fa-shield"></i>
 		<h2><a href="/security/">Security</a></h2>
 		<ul>
@@ -281,27 +298,20 @@
 			<li><a href="/security/wordpress.html">WordPress Security</a></li>
 			<li><a href="/security/cryptolocker.html">Cryptolocker</a></li>
 			<li><a href="/security/dirtycow.html">Dirty COW</a></li>
-			<!--<li><a href="logjam.html">The Logjam attack</a></li>
-			<li><a href="meltdown.html">Meltdown and Spectre</a></li>
-			<li><a href="memcachedopen.html">Memcached security concerns and reflection/amplification DDoS attacks</a></li>
-			<li><a href="wannacry.html">Wana Decryptor / Wana Decrypt0r 2.0 / WannaCry</a></li>-->
-		</ul>
-	</div>
-	<div class="grid-item box col2">
-		<i class="fa fa-envelope-o"></i>
-		<h2><a href="/email/">Email</a></h2>
-		<ul>
-			<li><a href="/email/mailconfig.html">Basic Email Config</a></li>
-			<li><a href="/desktop/sharedexchange/index.html">Shared Exchange</a></li>
-			<li><a href="/email/bounces.html">Legitimate Mail Being Blocked/Bouncing</a></li>
-			<li><a href="/email/dkim.html">DomainKeys Identified Mail (DKIM)</a></li>
-			<li><a href="/email/spf.html">Sender Policy Framework (SPF) records</a></li>
-			<li><a href="/email/postfix.html">Postfix mail transfer agent</a></li>
-			<li><a href="/email/hmail-antispam-setup.html">hMailServer - Anti-spam Setup</a></li>
-			
 		</ul>
 	</div>
 	<div class="grid-item box">
+		<i class="fa fa-shopping-cart"></i>
+		<h2><a href="/dr-ha/">eCommerce Stacks</a></h2>
+		<ul>
+			<li><a href="/ecommercestacks/magento/magento1/index.html">Magento 1</a></li>
+			<li><a href="/ecommercestacks/magento/magento2/index.html">Magento 2</a></li>
+			<li><a href="/ecommercestacks/shopware/index.html">Shopware</a></li>
+			<li><a href="/ecommercestacks/woocommerce/index.html">WooCommerce</a></li>
+		</ul>
+	</div>
+	
+	<div class="grid-item box col2">
 		<i class="fa fa-heartbeat"></i>
 		<h2><a href="/monitoring/">Monitoring and usage management</a></h2>
 		<ul>
@@ -313,7 +323,7 @@
 			<li><a href="/monitoring/dpack/index.html">Using DPACK to monitor server/virtual machine performance</a></li>
 		</ul>
 	</div>
-	<div class="grid-item box col2">
+	<div class="grid-item box">
 		<i class="fa fa-sitemap"></i>
 		<h2><a href="/network/">Networking</a></h2>
 		<ul>
@@ -324,7 +334,7 @@
 			<li><a href="/network/policy/index.html">Policy</a></li>
 		</ul>
 	</div>
-	<div class="grid-item box">
+	<div class="grid-item box col2">
 		<i class="fa fa-laptop"></i>
 		<h2><a href="/operatingsystems/">Operating Systems</a></h2>
 		<ul>
@@ -333,27 +343,17 @@
 			<li><a href="/operatingsystems/windows/index.html">Windows</a></li>
 		</ul>
 	</div>
-	<div class="grid-item box col2">
+	<div class="grid-item box">
 	
 		<i class="fa fa-line-chart"></i>
 		<h2><a href="/ltaas/">Load Testing</a></h2>
 	
 	</div>
-	<div class="grid-item box">
+	<div class="grid-item box col2">
 		<i class="fa fa-rocket"></i>
 		<h2><a href="webcel/">Webcelerator</a></h2>
 	</div>
-
-        {% set theTocTree = toctree()
-        | replace("</a>", "")
-        | replace(" href=\"", "></a>")
-        | replace("</li>", "</li>;")
-        | striptags
-        | replace("\">", "%") %}
-
-	{% set theTocTree = theTocTree.split(";") %}
-    {% set open = 0 %}
-	
+    
   </div>
 </div>
     {%- else -%}
@@ -377,11 +377,15 @@
 			
 					<ul id="breadcrumb">
 						<li><a href="/">Home</a> &gt;</li>
-						{%- for parent in parents %}
-						<li><a href="{{ parent.link|e }}">{{ parent.title }}</a>{{ reldelim1 }} &gt;</li>
+						{%- for parent in parents -%}
+						<li><a href="{{ parent.link|e }}">{{ parent.title }}</a> &gt;</li>
+						{%- endfor -%}
+						{%- for element in theTocTree -%}
+							{%- set el = element.split("%") %}
+							{%- set url = el[0] | trim | safe %}{% set BreadCrumbTitle = el[1] | trim | safe -%}
+							{%- if url == '#' -%}<li>{{ BreadCrumbTitle }}</li>
+							{%- endif %}
 						{%- endfor %}
-						<li>{{ title }}</li>
-						
 					</ul>
 				
 					{% block body %} {% endblock %}

--- a/source/ecloud/flex/index.rst
+++ b/source/ecloud/flex/index.rst
@@ -16,7 +16,7 @@ General Information
 .. toctree::
    :maxdepth: 1
 
-   general/index
+   General Information <general/index>
 
 ----------------------------------------
 Managing Resources
@@ -25,10 +25,10 @@ Managing Resources
 .. toctree::
    :maxdepth: 1
 
-   resources/index
-   resources/compute/index
-   resources/network/index
-   resources/storage/index
+   Managing Resources <resources/index>
+   Compute <resources/compute/index>
+   Network <resources/network/index>
+   Storage <resources/storage/index>
    resources/lbaas/index
    resources/orchestration/index
    


### PR DESCRIPTION
and use for the current page breadcrumb instead of the page.title (which pulls meta title)

add ecommerce stacks into homepage boxes
Added example nav override into eCloud flex

closes #644 
closes #645 