### PR TITLE
Fixing URL on keypress within search results

### DIFF
--- a/populator/main.py
+++ b/populator/main.py
@@ -258,7 +258,7 @@ if __name__ == '__main__':
         if missing_metadata:
             missing_meta.append(file)
 
-        output['url'] = file.replace('.md', '.html')
+        output['url'] = re.sub(r'^source/','/',file.replace('.md', '.html'))
         es.index(index=index_name, body=output)
 
     logging.info('Total documents missing meta tags {}/{}:'.format(len(missing_meta), len(files)))


### PR DESCRIPTION
Adding (back) a source replacement in the URLs, but this time only at the start.

Fixes where enter keypress on search result even uses this URL instead of the url presented in the search results.

/closes #653 