### PR TITLE
Fixed 'source' being dropped from URLs

### DIFF
--- a/source/_themes/ukf/static/search.js
+++ b/source/_themes/ukf/static/search.js
@@ -71,7 +71,7 @@ App.Search = (function () {
     $.each(results, function (index, item) {
       var li = $('<li></li>');
       var link = $('<a></a>');
-      link.attr('href', url + item["_source"].url.replace("source", ""));
+      link.attr('href', url + item["_source"].url);
       if (item["_source"].title) {
         link.append('<strong>' + item["_source"].title + '</strong><br />');
       }


### PR DESCRIPTION
Found another instance of the substring 'source' being dropped from URLs. Quick fix.

https://github.com/ukfast/docs.ukfast.co.uk/issues/706