### PR TITLE
Fixes CI with hardcoded dependancy versions numbers

### DIFF
--- a/populator/Dockerfile
+++ b/populator/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim
-ADD ./populator/main.py /
+ADD ./populator /
 ADD ./source /source
-RUN pip install elasticsearch requests markdown html2text bs4
+RUN pip install -r requirements.txt
 CMD ["python", "-u", "main.py"]

--- a/populator/requirements.txt
+++ b/populator/requirements.txt
@@ -1,0 +1,13 @@
+beautifulsoup4==4.9.2
+bs4==0.0.1
+certifi==2020.6.20
+chardet==3.0.4
+elasticsearch==7.9.1
+html2text==2020.1.16
+idna==2.10
+importlib-metadata==2.0.0
+markdown==3.2.2
+requests==2.24.0
+soupsieve==2.0.1
+urllib3==1.25.10
+zipp==3.2.0


### PR DESCRIPTION
The latest requests and urllib3 libs aren't getting along with each other. This rolls them back to their last known co-operative versions to fix the CI pipeline.