### PR TITLE
Use GitLab for deployment CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,25 @@
 language: python
 python:
 - '3.8'
-before_install:
-- echo "TRAVIS_PULL_REQUEST is '${TRAVIS_PULL_REQUEST}'"
-install:
-- pip install Sphinx
-- pip install recommonmark
-script:
-- ./tests.sh
-- sphinx-build -n -b html -d build/doctrees source/ build/html
-- make build/html/_static/css/app.css
-- make build/html/_static/app.js
+jobs:
+  include:
+  - name: Lint changed files
+    if: branch != master
+    before_install:
+    - echo "TRAVIS_PULL_REQUEST is '${TRAVIS_PULL_REQUEST}'"
+    install:
+    - pip install Sphinx
+    - pip install recommonmark
+    script:
+    - ./tests.sh
+    - sphinx-build -n -b html -d build/doctrees source/ build/html
+    - make build/html/_static/css/app.css
+    - make build/html/_static/app.js
+  - name: Start GitLab CI to deploy updated docs
+    if: branch = master
+    script:
+    - >
+      curl -X POST \
+        -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }} \
+        -F ref=master \
+        https://gitlab.devops.ukfast.co.uk/api/v4/projects/2570/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ jobs:
   include:
 
   - name: Lint changed files
-    if: branch != master
+    branches:
+      except:
+        - master
     before_install:
     - echo "TRAVIS_PULL_REQUEST is '${TRAVIS_PULL_REQUEST}'"
     install:
@@ -18,10 +20,14 @@ jobs:
     - make build/html/_static/app.js
 
   - name: Start GitLab CI to deploy updated docs
-    if: branch = master
+    branches:
+      only:
+        - master
+    env:
+      GITLAB_PIPELINE_TRIGGER_TOKEN: ${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }}
     script:
     - >
       curl -X POST
-      -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }}
+      -F token="$GITLAB_PIPELINE_TRIGGER_TOKEN"
       -F ref=master
       https://gitlab.devops.ukfast.co.uk/api/v4/projects/2570/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '3.8'
 jobs:
   include:
+
   - name: Lint changed files
     if: branch != master
     before_install:
@@ -15,11 +16,12 @@ jobs:
     - sphinx-build -n -b html -d build/doctrees source/ build/html
     - make build/html/_static/css/app.css
     - make build/html/_static/app.js
+
   - name: Start GitLab CI to deploy updated docs
     if: branch = master
     script:
     - >
-      curl -X POST \
-        -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }} \
-        -F ref=master \
-        https://gitlab.devops.ukfast.co.uk/api/v4/projects/2570/trigger/pipeline
+      curl -X POST
+      -F token=${{ secrets.GITLAB_PIPELINE_TRIGGER_TOKEN }}
+      -F ref=master
+      https://gitlab.devops.ukfast.co.uk/api/v4/projects/2570/trigger/pipeline


### PR DESCRIPTION
This PR changes the way `docs.ukfast.co.uk` is deployed, switching from repository mirroring to having Travis trigger the deployment pipeline in our GitLab instance