### PR TITLE
Switch FAQ links to docs.ukfast.co.uk links

### DIFF
--- a/source/domains/domains/faqs/how-do-i-add-my-domain-into-myukfast.md
+++ b/source/domains/domains/faqs/how-do-i-add-my-domain-into-myukfast.md
@@ -10,5 +10,5 @@
 To add a domain to your MyUKFast account you can use the import domain function in [Domains > Import a Domain](https://my.ukfast.co.uk/domains/import.php).
 
 
-This will add it to our system, however, to manage the domain you must first [transfer it to us](https://my.ukfast.co.uk/faq/view/1311.html).
+This will add it to our system, however, to manage the domain you must first :doc:`transfer it to us</domains/domains/transferin>`.
 

--- a/source/domains/domains/faqs/how-do-i-check-where-a-domain-is-registered.md
+++ b/source/domains/domains/faqs/how-do-i-check-where-a-domain-is-registered.md
@@ -7,7 +7,7 @@
 ```
 
 
-You can use a whois lookup service such as <a href=""http://who.is"">http://who.is</a>
+You can use a whois lookup service such as <a href="http://who.is">http://who.is</a>
 
 
 .

--- a/source/domains/domains/faqs/how-do-i-check-where-a-domain-is-registered.md
+++ b/source/domains/domains/faqs/how-do-i-check-where-a-domain-is-registered.md
@@ -7,7 +7,7 @@
 ```
 
 
-You can use a whois lookup service such as <a href="http://who.is">http://who.is</a>
+You can use a whois lookup service such as [http://who.is](http://who.is)
 
 
 .

--- a/source/domains/domains/faqs/ive-just-registered-a--ltd-uk--plc-uk--net-uk-domain-but-its-not-showing-as-registered.md
+++ b/source/domains/domains/faqs/ive-just-registered-a--ltd-uk--plc-uk--net-uk-domain-but-its-not-showing-as-registered.md
@@ -7,7 +7,7 @@
 ```
 
 
-Upon registration request .ltd.uk (Private Limited Companies)/.plc.uk (Public Limited Companies)/net.uk (Internet Service Providers' infrastructure) domains are manually checked by Nominet to ensure they meet their strict <a href="http://www.nominet.org.uk/uk-domain-names/registering-uk-domain/choosing-domain-name/rules">domain name requirements</a>.
+Upon registration request .ltd.uk (Private Limited Companies)/.plc.uk (Public Limited Companies)/net.uk (Internet Service Providers' infrastructure) domains are manually checked by Nominet to ensure they meet their strict [domain name requirements](http://www.nominet.org.uk/uk-domain-names/registering-uk-domain/choosing-domain-name/rules).
 
 
 As the process is manual it may take a little extra time; especially if you made the request in the evening or at the weekend.

--- a/source/domains/domains/faqs/ive-just-registered-a--ltd-uk--plc-uk--net-uk-domain-but-its-not-showing-as-registered.md
+++ b/source/domains/domains/faqs/ive-just-registered-a--ltd-uk--plc-uk--net-uk-domain-but-its-not-showing-as-registered.md
@@ -7,11 +7,11 @@
 ```
 
 
-Upon registration request .ltd.uk (Private Limited Companies)/.plc.uk (Public Limited Companies)/net.uk (Internet Service Providers' infrastructure) domains are manually checked by Nominet to ensure they meet their strict <a href=""http://www.nominet.org.uk/uk-domain-names/registering-uk-domain/choosing-domain-name/rules"">domain name requirements</a>.
+Upon registration request .ltd.uk (Private Limited Companies)/.plc.uk (Public Limited Companies)/net.uk (Internet Service Providers' infrastructure) domains are manually checked by Nominet to ensure they meet their strict <a href="http://www.nominet.org.uk/uk-domain-names/registering-uk-domain/choosing-domain-name/rules">domain name requirements</a>.
 
 
 As the process is manual it may take a little extra time; especially if you made the request in the evening or at the weekend.
 
 
-If your domain is still not showing as registered, try checking our <a href=""https://my.ukfast.co.uk/faq/view/1262.html"">.ltd.uk</a>, <a href=""https://my.ukfast.co.uk/faq/view/1263.html"">.plc.uk</a>, or <a href=""https://my.ukfast.co.uk/faq/view/1270.html"">.net.uk</a> special requirements FAQs; we will also contact you if there are any problems with your registration.
+If your domain is still not showing as registered, try checking our :doc:`.ltd.uk</domains/domains/faqs/what-are-the-special-requirements-for-registering-a--ltd-uk-domain>`, :doc:`.plc.uk</domains/domains/faqs/what-are-the-special-requirements-for-registering-a--plc-uk-domain>`, or :doc:`.net.uk</domains/domains/faqs/what-are-the-special-requirements-for-registering-a--net-uk-domain>` special requirements FAQs; we will also contact you if there are any problems with your registration.
 

--- a/source/domains/domains/faqs/ive-registered-a-domain-with-another-company-how-do-i-point-it-to-my-server-or-hosting-space-with-you.md
+++ b/source/domains/domains/faqs/ive-registered-a-domain-with-another-company-how-do-i-point-it-to-my-server-or-hosting-space-with-you.md
@@ -58,7 +58,7 @@ Next you need to add the e-mail services. This will require three things:
 3. An 'MX' record which tells other e-mail services how-to get in touch with your server when trying to deliver mail
 
 
-To add an 'A' record just repeat the steps above, but now we're adding something new: an 'MX' record. We've got[ a guide for that ](https://my.ukfast.co.uk/faq/view/1054.html)too, and it also shows you how-to add the 'A' record part!
+To add an 'A' record just repeat the steps above, but now we're adding something new: an :doc:`'MX' record</domains/safedns/recordtypes>`. 
 
 
 Once you've completed the last stage, your domain is ready to go and will be serving up the basic services of web-sites and e-mail.

--- a/source/domains/domains/faqs/ive-registered-a-domain-with-another-company-how-do-i-point-it-to-my-server-or-hosting-space-with-you.md
+++ b/source/domains/domains/faqs/ive-registered-a-domain-with-another-company-how-do-i-point-it-to-my-server-or-hosting-space-with-you.md
@@ -34,7 +34,7 @@ How this is done depends entirely on the control panel offered by your registrar
 Once the name servers are in place and the information has been transmitted, it's time to add the relevant records to your DNS zone. Depending on what services you offer you will need different records, but in our example below we're going to assume simple web services and e-mail.
 
 
-Let's start with the web services. First we need to create an 'A' record for out domain, and also the 'www' sub-domain. We've already written a handy guide on [how to add sub-domains and 'A' records to your domain](https://my.ukfast.co.uk/faq/view/1053.html), so please consult this guide and when you're done, then pop back here to read on. Now that you're an expert on adding 'A' records to your domain, let's list the information you need and the records you need to create:
+Let's start with the web services. First we need to create an 'A' record for out domain, and also the 'www' sub-domain. We've already written a handy guide on :doc:`how to add sub-domains and 'A' records to your domain</domains/safedns/addarecord>`, so please consult this guide and when you're done, then pop back here to read on. Now that you're an expert on adding 'A' records to your domain, let's list the information you need and the records you need to create:
 
 
 1. The IP address of your server. This can be found under the Services > Dedicated Servers tab in MyUKFast. (If you don't have a dedicated server, select the relevant solution; for example, 'Cloud')

--- a/source/domains/domains/faqs/what-are-the-domain-billing-contact-details-used-for.md
+++ b/source/domains/domains/faqs/what-are-the-domain-billing-contact-details-used-for.md
@@ -7,6 +7,6 @@
 ```
 
 
-Your domain billing information is one of four types of contact information required by [(WHOIS)](https://my.ukfast.co.uk/faq/view/1264.html) 
-to go with a domain ([(registrant)](https://my.ukfast.co.uk/faq/view/1257.html), administrator, technical and billing); the details will be used for any payment related contact.
+Your domain billing information is one of four types of contact information required by :doc:`WHOIS</domains/domains/faqs/what-is-whois>` 
+to go with a domain :doc:`registrant</domains/domains/faqs/what-is-a-domain-registrant>`, administrator, technical and billing); the details will be used for any payment related contact.
 

--- a/source/domains/domains/faqs/what-are-the-domain-technical-contact-details-used-for.md
+++ b/source/domains/domains/faqs/what-are-the-domain-technical-contact-details-used-for.md
@@ -7,5 +7,5 @@
 ```
 
 
-When you register a domain name you have to provide technical contact details for [(WHOIS)](https://my.ukfast.co.uk/faq/view/1264.html). This person will receive all technical questions regarding the domain name.
+When you register a domain name you have to provide technical contact details for :doc:`WHOIS</domains/domains/faqs/what-is-whois>`. This person will receive all technical questions regarding the domain name.
 

--- a/source/domains/domains/faqs/what-are-the-new-icann-rules-for-registering-domains.md
+++ b/source/domains/domains/faqs/what-are-the-new-icann-rules-for-registering-domains.md
@@ -7,7 +7,7 @@
 ```
 
 
-Before the release of the new gTLDs, [(ICANN)](https://my.ukfast.co.uk/faq/view/1256.html) began to tidy up the domain registration rules, as previously lots of inaccurate information was causing problems.
+Before the release of the new gTLDs, :doc:`ICANN</domains/domains/faqs/who-are-icann>` began to tidy up the domain registration rules, as previously lots of inaccurate information was causing problems.
 
 
 The new rules boil down to:

--- a/source/domains/domains/faqs/what-are-the-requirements-to-register-a--jobs-domain.md
+++ b/source/domains/domains/faqs/what-are-the-requirements-to-register-a--jobs-domain.md
@@ -10,7 +10,7 @@
 Before you can register a .JOBS domain, there are certain requirements that need to be fulfilled:
 
 
-The [(registrant)](https://my.ukfast.co.uk/faq/view/1257.html) must be a corporation or organisation, individuals are not permitted to register a .JOBS domain
+The :doc:`registrant</domains/domains/faqs/what-is-a-domain-registrant>` must be a corporation or organisation, individuals are not permitted to register a .JOBS domain
 
 
 The domain name must be the legal or commonly known business name of the company registering the domain.

--- a/source/domains/domains/faqs/what-are-the-special-requirements-for-registering-a--ltd-uk-domain.md
+++ b/source/domains/domains/faqs/what-are-the-special-requirements-for-registering-a--ltd-uk-domain.md
@@ -7,7 +7,7 @@
 ```
 
 
-[(Nominet)](https://my.ukfast.co.uk/faq/view/1260.html) have special requirements that a .ltd.uk (limited) domain must meet before they will register it. As an overview you can only register a .ltd.uk domain if:
+:doc:`Nominet</domains/domains/faqs/who-are-nominet>` have special requirements that a .ltd.uk (limited) domain must meet before they will register it. As an overview you can only register a .ltd.uk domain if:
 
 <ul>
 <li>The registrant is a limited company and has limited or Ltd in their company name</li>

--- a/source/domains/domains/faqs/what-are-the-special-requirements-for-registering-a--plc-uk-domain.md
+++ b/source/domains/domains/faqs/what-are-the-special-requirements-for-registering-a--plc-uk-domain.md
@@ -7,7 +7,7 @@
 ```
 
 
-[(Nominet )](https://my.ukfast.co.uk/faq/view/1260.html)have special requirements that a .plc.uk (limited) domain must meet before they will register it. As an overview you can only register a .plc.uk domain if:
+:doc:`Nominet</domains/domains/faqs/who-are-nominet>` have special requirements that a .plc.uk (limited) domain must meet before they will register it. As an overview you can only register a .plc.uk domain if:
 
 <ul>
 <li>The registrant is a limited company and has public limited or Plc in their company name</li>

--- a/source/domains/domains/faqs/what-are-ukfasts-name-servers.md
+++ b/source/domains/domains/faqs/what-are-ukfasts-name-servers.md
@@ -7,7 +7,7 @@
 ```
 
 
-UKFast [(name servers)](https://my.ukfast.co.uk/faq/view/1266.html) are:
+UKFast :doc:`name servers</domains/domains/faqs/what-is-a-name-server>` are:
 
 
 ns0.ukfast.net

--- a/source/domains/domains/faqs/what-do-the-domain-verification-statuses-mean.md
+++ b/source/domains/domains/faqs/what-do-the-domain-verification-statuses-mean.md
@@ -7,7 +7,7 @@
 ```
 
 
-When you view domains in MyUKFast addition to &lsquo;[(suspended)](https://my.ukfast.co.uk/faq/view/1295.html)', you may see the following verification statuses:
+When you view domains in MyUKFast in addition to :doc:`'suspended'</domains/domains/faqs/what-does-it-mean-if-my-domain-is-suspended>`, you may see the following verification statuses:
 
 
 &bull; Unverified --The validation process has not been initiated.

--- a/source/domains/domains/faqs/what-does-domain-pre-order-mean.md
+++ b/source/domains/domains/faqs/what-does-domain-pre-order-mean.md
@@ -10,7 +10,7 @@
 If you wish to reserve a domain before it is officially released, you can pre-order it through some registrars.
 
 
-When you pre-order a domain name your registration request will be queued and be processed as soon as the domain becomes available to the general public. Orders are processed at the registry on a first come, first served basis; and if there is more than one order for the same name, the first order to be placed will be able register the name (unless there are special conditions, such as with the [(.london domain allocation)](https://my.ukfast.co.uk/faq/view/1307.html)).
+When you pre-order a domain name your registration request will be queued and be processed as soon as the domain becomes available to the general public. Orders are processed at the registry on a first come, first served basis; and if there is more than one order for the same name, the first order to be placed will be able register the name.
 
 
 Should your request be unsuccessful credit will be applied on your account.

--- a/source/domains/domains/faqs/what-does-import-my-domain-do.md
+++ b/source/domains/domains/faqs/what-does-import-my-domain-do.md
@@ -13,5 +13,5 @@ Import my domain adds your domain record into MyUKFast, but it's important to be
 It's primarily used if you transfer, or are going to transfer, a .uk domain to us. You can import it via Domains > Import a Domain. Then once you have changed the tag you will be able to manage it through MyUKFast.
 
 
-To import a non .uk domain you can follow the instructions found in [(How do I transfer a domain to UKFast)](https://my.ukfast.co.uk/faq/view/1311.html).
+To import a non .uk domain you can follow the instructions found in :doc:`How do I transfer a domain to UKFast</domains/domains/faqs/how-do-i-transfer-a-domain-to-ukfast>`.
 

--- a/source/domains/domains/faqs/what-does-it-mean-if-my-domain-is-suspended.md
+++ b/source/domains/domains/faqs/what-does-it-mean-if-my-domain-is-suspended.md
@@ -1,9 +1,9 @@
-# What does it mean if my domain is ""suspended"?
+# What does it mean if my domain is "suspended"?
 
 ```eval_rst
-   .. title:: Domain Name FAQ What does it mean if my domain is ""suspended""?"
+   .. title:: Domain Name FAQ What does it mean if my domain is "suspended"?
    .. meta::
-       :description: Domain Name FAQ What does it mean if my domain is ""suspended""?"
+       :description: Domain Name FAQ What does it mean if my domain is "suspended"?
 ```
 
 

--- a/source/domains/domains/faqs/what-is-a-domain-epp-authorisation-code.md
+++ b/source/domains/domains/faqs/what-is-a-domain-epp-authorisation-code.md
@@ -7,7 +7,7 @@
 ```
 
 
-An EPP code - or authorisation code - is a unique code given to each domain by its [(registrar)](https://my.ukfast.co.uk/faq/view/1259.html) as an extra level of security, much like a password.
+An EPP code - or authorisation code - is a unique code given to each domain by its :doc:`registrar</domains/domains/faqs/what-is-a-domain-registrar>` as an extra level of security, much like a password.
 
 
 If you want to transfer your domain to a new registrar, you need to give them your EPP; you can get it from your current registrar.

--- a/source/domains/domains/faqs/what-is-a-domain-ips-tag.md
+++ b/source/domains/domains/faqs/what-is-a-domain-ips-tag.md
@@ -7,7 +7,7 @@
 ```
 
 
-An Internet Provider Security (IPS) tag - also known as a registrar tag, domain tag, Nominet provider tag, or IPS key - is a unique code issued by Nominet to every UK [(registrar)](https://my.ukfast.co.uk/faq/view/1259.html). Every .uk domain is assigned one to identify which registrar has control of that domain.
+An Internet Provider Security (IPS) tag - also known as a registrar tag, domain tag, Nominet provider tag, or IPS key - is a unique code issued by Nominet to every UK :doc:`registrar</domains/domains/faqs/what-is-a-domain-registrar>`. Every .uk domain is assigned one to identify which registrar has control of that domain.
 
 
 IPS tags are a single sequence of numbers and/or letters that are capitalised e.g. UKFast's tag is UKFAST.

--- a/source/domains/domains/faqs/what-is-a-domain-registrant.md
+++ b/source/domains/domains/faqs/what-is-a-domain-registrant.md
@@ -7,7 +7,7 @@
 ```
 
 
-A domain registrant is the person who a [(domain name)](https://my.ukfast.co.uk/faq/view/1251.html) is registered to and therefore, in effect, owns it. They will be the person who applied to a registrar for the domain and holds the right to use it.
+A domain registrant is the person who a :doc:`domain name</domains/domains/faqs/what-is-a-domain-name>` is registered to and therefore, in effect, owns it. They will be the person who applied to a registrar for the domain and holds the right to use it.
 
 
 If you're a registrant you will receive renewal and administrative notices for your domain and it will remain yours should you choose to renew it when it comes to expire.

--- a/source/domains/domains/faqs/what-is-a-domain-registrar.md
+++ b/source/domains/domains/faqs/what-is-a-domain-registrar.md
@@ -7,7 +7,7 @@
 ```
 
 
-A domain registrar is a company that offers [(domain name)](https://my.ukfast.co.uk/faq/view/1251.html) registration, often on behalf of others. For example, GoDaddy.com is one of the most famous (and biggest) registrars.
+A domain registrar is a company that offers :doc:`domain name</domains/domains/faqs/what-is-a-domain-name>` registration, often on behalf of others. For example, GoDaddy.com is one of the most famous (and biggest) registrars.
 
 
 If you buy a domain name through one registrar you can switch to another; which you might do because of competitive pricing, features, or a problem with the registrar.

--- a/source/domains/domains/faqs/what-is-a-domain-registry.md
+++ b/source/domains/domains/faqs/what-is-a-domain-registry.md
@@ -7,7 +7,7 @@
 ```
 
 
-A domain registry holds a database of domain names, and information that goes with them, like who owns it and when it expires. Each registry maintains different TLDs, for example, Nominet looks after .uk [(domain names)](https://my.ukfast.co.uk/faq/view/1251.html) and DENIC does the same for .de in Germany.
+A domain registry holds a database of domain names, and information that goes with them, like who owns it and when it expires. Each registry maintains different TLDs, for example, Nominet looks after .uk :doc:`domain names</domains/domains/faqs/what-is-a-domain-name>` and DENIC does the same for .de in Germany.
 
 
 Some registries sell domain names directly (like SWITCH in Switzerland) but many use authorised resellers (or registrars) who you buy and register domain names through.

--- a/source/domains/domains/faqs/what-is-a-gtld.md
+++ b/source/domains/domains/faqs/what-is-a-gtld.md
@@ -7,7 +7,7 @@
 ```
 
 
-gTLDs (or generic top-level domain names) are the most common kind of top-level [(domain names)](https://my.ukfast.co.uk/faq/view/1252.html), and the ones we're most used to seeing. They function as part of the internet system we use to help us map and remember a website's numerical IP addresses - also called the Domain Name System (DNS). gTLDs have three or more characters and follow the &lsquo;dot' part of the address e.g. .com, .org etc.
+gTLDs (or generic top-level domain names) are the most common kind of top-level :doc:`domain names</domains/domains/faqs/what-is-a-domain-name>`, and the ones we're most used to seeing. They function as part of the internet system we use to help us map and remember a website's numerical IP addresses - also called the Domain Name System (DNS). gTLDs have three or more characters and follow the &lsquo;dot' part of the address e.g. .com, .org etc.
 
 
 We use gTLDs essentially because they allow us to gather more information about the site that we're visiting; for example, they can give us information about the business, what it does and its location.

--- a/source/domains/domains/faqs/what-is-an-sld.md
+++ b/source/domains/domains/faqs/what-is-an-sld.md
@@ -7,7 +7,7 @@
 ```
 
 
-A Second Level Domain (SLD) is the part of the address that comes directly before the [(Top Level Domain)](https://my.ukfast.co.uk/faq/view/1252.html) (TLD), and usually provides more information on the organisation that registered the domain.
+A Second Level Domain (SLD) is the part of the address that comes directly before the :doc:`Top Level Domain (TLD)</domains/domains/faqs/what-is-a-tld>`, and usually provides more information on the organisation that registered the domain.
 
 
 In many cases the SLD is the middle bit of a domain that goes between &lsquo;www.' and the domain name extension (for example, .com, .org) at the end of the address. For example, in [www.ukfast.co.uk](http://www.ukfast.co.uk), &lsquo;ukfast' is the SLD.

--- a/source/domains/domains/faqs/what-is-domain-privacy.md
+++ b/source/domains/domains/faqs/what-is-domain-privacy.md
@@ -7,10 +7,10 @@
 ```
 
 
-This option allows you to replace your real contact details on the [(WHOIS)](https://my.ukfast.co.uk/faq/view/1264.html) database with a proxy, to keep your details private. If anyone needs to contact you, correspondence will be sent through the proxy.
+This option allows you to replace your real contact details on the :doc:`WHOIS</domains/domains/faqs/what-is-whois>` database with a proxy, to keep your details private. If anyone needs to contact you, correspondence will be sent through the proxy.
 
 
-Certain domain [(registries)](https://my.ukfast.co.uk/faq/view/1254.html) charge for this service and some offer it for free.
+Certain domain :doc:`registries</domains/domains/faqs/what-is-a-domain-registry>` charge for this service and some offer it for free.
 
 
 Privacy can also be enabled after registration; however, you will still be charged the full amount no matter how close you are to the renewal date. You will also always be charged on the renewal date if it still enabled, regardless of when it was enabled. You can purchase it through UKFast for £;3 per year when you register a domain name; and then your account will be charged £;3 each year when the domain is renewed, if it is still enabled.

--- a/source/domains/domains/faqs/what-is-the-ips-tag-for-ukfast.md
+++ b/source/domains/domains/faqs/what-is-the-ips-tag-for-ukfast.md
@@ -7,7 +7,7 @@
 ```
 
 
-If you are transferring a domain into UKFast, the [(IPS tag )](https://my.ukfast.co.uk/faq/view/1258.html)is UKFAST.
+If you are transferring a domain into UKFast, the :doc:`IPS tag</domains/domains/faqs/what-is-a-domain-ips-tag>` is UKFAST.
 
 
 Please ensure that you import the domain into your MyUKFast portal, this can found under Services, then Domain Management.

--- a/source/domains/domains/faqs/who-are-icann.md
+++ b/source/domains/domains/faqs/who-are-icann.md
@@ -7,10 +7,10 @@
 ```
 
 
-ICANN, short for &lsquo;The Internet Corporation for Assigned Names and Numbers', are a not-for-profit organisation that controls the rules and regulations with regards to [(domain names)](https://my.ukfast.co.uk/faq/view/1251.html).
+ICANN, short for &lsquo;The Internet Corporation for Assigned Names and Numbers', are a not-for-profit organisation that controls the rules and regulations with regards to :doc:`domain names</domains/domains/faqs/what-is-a-domain-name>`.
 
 
-They regulate the registration and the use of domain names for the [(Generic Top Level Domains)](https://my.ukfast.co.uk/faq/view/1253.html), such as .com, .net or .org., and are in the process of rolling out a huge number of new TLDs.
+They regulate the registration and the use of domain names for the :doc:`Generic Top Level Domains</domains/domains/faqs/what-is-a-gtld>`, such as .com, .net or .org., and are in the process of rolling out a huge number of new TLDs.
 
 
 Registrars and registries have to comply with the rules set by ICANN, applying them to you - the registrant. In a push to tidy up domain name registration information and ensure that all details are up to date and accurate they have recently added extra checks and procedures for registrants to confirm details. Failure to do so on new registrations or changes of details leads to the domain being suspended.

--- a/source/domains/domains/faqs/who-are-nominet.md
+++ b/source/domains/domains/faqs/who-are-nominet.md
@@ -7,7 +7,7 @@
 ```
 
 
-Nominet is an internet [(registry)](https://my.ukfast.co.uk/faq/view/1254.html) company in the UK. It manages the .uk domain space, and from 2014 will run .cymru and .wales too.
+Nominet is an internet :doc:`registry</domains/domains/faqs/what-is-a-domain-registry>` company in the UK. It manages the .uk domain space, and from 2014 will run .cymru and .wales too.
 
 
 Registering and renewing these domains are done through one of the many registrars (like UKFast) that work with Nominet.

--- a/source/dr-ha/techniques/linuxdbservers.md
+++ b/source/dr-ha/techniques/linuxdbservers.md
@@ -111,4 +111,4 @@ This can then be ran nightly as a cron job as mentioned in the previous section.
 
 ## Next steps
 
-Once you're confident that you have consistent backups using one of the above two methods, you should now be good to follow the [Setting backup exclusions](https://my.ukfast.co.uk/faq/1090.html) guide to exclude `/var/lib/mysql` (or wherever else you may keep your data directory) from your backup run to save some space.
+Once you're confident that you have consistent backups using one of the above two methods, you should now be good to follow the :doc:`Setting backup exclusions</dr-ha/ukfast_backup/backup_schedule>` guide to exclude `/var/lib/mysql` (or wherever else you may keep your data directory) from your backup run to save some space.


### PR DESCRIPTION
The FAQs were moved over to docs.ukfast.co.uk but quite a lot of the old FAQs linked to other FAQs and this is still the same with docs.ukfast.co.uk.

I've swapped the FAQ links to the new doc.ukfast.co.uk pages.

I've not been able to test these changes as I can't get the project running on my computer but I've followed the link instructions in the README