### PR TITLE
Cpanel php meta changes

### DIFF
--- a/source/operatingsystems/linux/controlpanels/cpanel_add_account.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_add_account.md
@@ -1,4 +1,4 @@
-# Adding an Account in WHM
+# How to Add a New Account in WHM
 
 Once you've got your WHM server setup, you're going to want to add an Account. In WHM, an Account can be thought of as a catch-all term for a domain and associated resources. When you add an Account, this creates:
 
@@ -35,9 +35,9 @@ For the final section, "Mail Routing Settings", choose the automatic configurati
 You've now added an account to WHM. You can now login, [using the guide here!](/operatingsystems/linux/controlpanels/cpanel_connect.html#connecting-to-cpanel)
 
 ```eval_rst
-  .. title:: Creating a cPanel Account
+  .. title:: cPanel | How to Add a New Account in WHM
   .. meta::
-     :title: Creating a cPanel Account | UKFast Documentation
-     :description: Creating a cPanel Account in WHM
+     :title: How to Add a New Account in WHM | UKFast Documentation
+     :description: How to Add a New Account in WHM
      :keywords: ukfast, cpanel, whm, domain, account, control, panel, tutorial, cloud, server, guide, virtual
 ```

--- a/source/operatingsystems/linux/controlpanels/cpanel_connect.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_connect.md
@@ -1,4 +1,4 @@
-# Connecting to WHM and cPanel
+# How to Log in to WHM and cPanel
 
 There are 2 components to a cPanel server. There's WHM, which is the interface to manage reseller accounts. Then there is cPanel, which is the control panel for each account.
 
@@ -40,9 +40,9 @@ Account Information >> List Accounts >> "cPanel" Button
 ![cPanel Button](files/cpanel_connect_from_whm.JPG)
 
 ```eval_rst
-  .. title:: Connecting to WHM or Cpanel
+  .. title:: cPanel | How to Log in to WHM and cPanel
   .. meta::
-     :title: Connecting to WHM or Cpanel | UKFast Documentation
+     :title: How to Log in to WHM and cPanel | UKFast Documentation
      :description: Guide on connecting to a WHM/cPanel server
      :keywords: ukfast, cpanel, whm, control, panel, tutorial, cloud, server, guide, virtual
 ```

--- a/source/operatingsystems/linux/controlpanels/cpanel_fixdeceptivesitewarning.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_fixdeceptivesitewarning.md
@@ -1,4 +1,4 @@
-# Fixing Deceptive Site warning on WHM Login
+# How to Fix the Deceptive Site warning on WHM Login
 
 Google Chrome's latest update is showing a "Deceptive site ahead" Warning on WHM for server using their default `srvlist.ukfast.net` hostname:
 
@@ -52,9 +52,9 @@ You will also need to update the server's rDNS in MyUKFast to match the new host
 
 
 ```eval_rst
-  .. title:: Fixing Deceptive Site warning on WHM Login
+  .. title:: cPanel | How to Fix the Deceptive Site warning on WHM Login
   .. meta::
-     :title: Fixing Deceptive Site warning on WHM Login
+     :title: How to Fix the Deceptive Site warning on WHM Login | UKFast Documentation
      :description:  A guide on how to fix WHM showing a deceptive site warning
      :keywords: ukfast, cpanel, whm, control, panel, fix, warning, deceptive, login
 ```

--- a/source/operatingsystems/linux/controlpanels/cpanel_ftp_account.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_ftp_account.md
@@ -1,4 +1,4 @@
-# Creating An FTP Account In cPanel
+# How to Create an FTP Account In cPanel
 
 You might need to create FTP accounts in cPanel, so that you and/or your developers can upload and download content from your website.
 
@@ -25,9 +25,9 @@ The last box is for "Quota". This determines how much bandwidth the FTP account 
 Now you can click "Create".
 
 ```eval_rst
-  .. title:: Creating An FTP Account In cPanel
+  .. title:: cPanel | How to Create an FTP Account In cPanel
   .. meta::
-     :title: Creating An FTP Account In cPanel | UKFast Documentation
-     :description: Creating an FTP Account in cPanel
+     :title: How to Create an FTP Account In cPanel | UKFast Documentation
+     :description: How to Create an FTP Account In cPanel
      :keywords: ukfast, cpanel, whm, control, panel, ftp, cloud, server, guide, virtual
 ```

--- a/source/operatingsystems/linux/controlpanels/cpanel_initial_setup.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_initial_setup.md
@@ -14,7 +14,7 @@ Unless you're using custom nameservers, you can use our SafeDNS nameservers here
 You're now ready to start using WHM/cPanel. [See our guide on adding accounts here!](/operatingsystems/linux/controlpanels/cpanel_add_account)
 
 ```eval_rst
-  .. title:: WHM Initial Setup
+  .. title:: cPanel | WHM Initial Setup
   .. meta::
      :title: WHM Initial Setup | UKFast Documentation
      :description: WHM initial setup page

--- a/source/operatingsystems/linux/controlpanels/cpanel_installapachemodule.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_installapachemodule.md
@@ -1,4 +1,4 @@
-# Installing an Apache Module via EasyApache4
+# How to Install an Apache Module with EasyApache4
 
 Before you begin to install an Apache Module on your WHM/cPanel server, you need to log in to your WHM Panel.
 Installing an Apache Module requires you to be logged into the WHM panel as opposed to cPanel for a specific domain, this is because access to EasyApache4 is required.
@@ -47,8 +47,9 @@ Once the process has finished, click the "Done" button to close your EasyApache4
 Using this guide, you have successfully installed an Apache Module using EasyApache4!
 
 ```eval_rst
-  .. title:: Installing an Apache Module via EasyApache4
+  .. title:: cPanel | How to Install an Apache Module with EasyApache4
   .. meta::
-     :title: Installing an Apache Module via EasyApache4
+     :title: How to Install an Apache Module with EasyApache4 | UKFast Documentation
      :description:  A guide to installing an Apache Module via EasyApache4
-     :keywords: ukfast, apache, module, easy, easyapache, easyapache4, cpanel, install
+     :keywords: ukfast, apache, module, cpanel, whm, easy, easyapache, easyapache4, install
+```

--- a/source/operatingsystems/linux/controlpanels/cpanel_installphpextension.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_installphpextension.md
@@ -47,8 +47,9 @@ Once the process has finished, click the "Done" button to close your EasyApache4
 Using this guide, you have successfully installed a PHP extension using EasyApache4!
 
 ```eval_rst
-  .. title:: Installing an Apache Module via EasyApache4
+  .. title:: cPanel | Installing a PHP Extension via EasyApache4
   .. meta::
-     :title: Installing an Apache Module via EasyApache4
-     :description:  A guide to installing an Apache Module via EasyApache4
-     :keywords: ukfast, php, extension, easy, easyapache, easyapache4, cpanel, install
+     :title: Installing a PHP Extension via EasyApache4 | UKFast Documentation
+     :description:  A guide for installing a PHP Extension via EasyApache4
+     :keywords: php, extension, module, easy, easyapache, easyapache4, cpanel, install``
+```

--- a/source/operatingsystems/linux/controlpanels/cpanel_installphpextension.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_installphpextension.md
@@ -1,4 +1,4 @@
-# Installing a PHP Extension via EasyApache4
+# How to Install a PHP Extension with EasyApache4
 
 Before you begin to install a PHP Extension on your WHM/cPanel server, you need to log in to your WHM Panel.
 Installing a PHP Extension requires you to be logged into the WHM panel as opposed to cPanel for a specific domain, this is because access to EasyApache4 is required.
@@ -47,9 +47,9 @@ Once the process has finished, click the "Done" button to close your EasyApache4
 Using this guide, you have successfully installed a PHP extension using EasyApache4!
 
 ```eval_rst
-  .. title:: cPanel | Installing a PHP Extension via EasyApache4
+  .. title:: cPanel | How to Install a PHP Extension with EasyApache4
   .. meta::
-     :title: Installing a PHP Extension via EasyApache4 | UKFast Documentation
-     :description:  A guide for installing a PHP Extension via EasyApache4
-     :keywords: php, extension, module, easy, easyapache, easyapache4, cpanel, install``
+     :title: How to Install a PHP Extension with EasyApache4 | UKFast Documentation
+     :description:  A guide for installing a PHP Extension with EasyApache4
+     :keywords: php, extension, cpanel, module, easy, easyapache, easyapache4, cpanel, install``
 ```

--- a/source/operatingsystems/linux/controlpanels/cpanel_installphpversion.md
+++ b/source/operatingsystems/linux/controlpanels/cpanel_installphpversion.md
@@ -1,4 +1,4 @@
-# Installing a PHP Version Module via EasyApache4
+# How to Install a PHP Version with EasyApache4
 
 Before you begin to install a PHP version on your WHM/cPanel server, you need to log in to your WHM Panel.
 Installing a PHP version requires you to be logged into the WHM panel as opposed to cPanel for a specific domain, this is because access to EasyApache4 is required.
@@ -47,8 +47,9 @@ Once the process has finished, click the "Done" button to close your EasyApache4
 Using this guide, you have successfully installed a PHP version using EasyApache4!
 
 ```eval_rst
-  .. title:: Installing an Apache Module via EasyApache4
+  .. title:: cPanel | How to Install a PHP Version with EasyApache4
   .. meta::
-     :title: Installing an Apache Module via EasyApache4
-     :description:  A guide to installing an Apache Module via EasyApache4
-     :keywords: ukfast, php, version easy, easyapache, easyapache4, cpanel, install
+     :title: How to Install a PHP Version with EasyApache4 | UKFast Documentation
+     :description:  A guide on how to install a PHP Version with EasyApache4
+     :keywords:  php, version, cpanel, easy, easyapache, easyapache4, cpanel, install
+```


### PR DESCRIPTION
amending the titles and meta of a few cpanel docs to group some commonly answered questions when you search for 'cpanel'

Also, three docs had the same meta so appeared thrice in the search listing, eg.

![image](https://user-images.githubusercontent.com/3035178/114739448-cac04c80-9d40-11eb-9a9b-a56ca81f91cb.png)
