### PR TITLE
Switched from initContainer to K8S Job

### DIFF
--- a/.ci/kustomize/base/app-deployment.yaml
+++ b/.ci/kustomize/base/app-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: app
   name: app
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: app
@@ -34,6 +34,3 @@ spec:
             port: 80
           initialDelaySeconds: 3
           periodSeconds: 10
-      initContainers:
-      - name: es-populator
-        image: populatorImage

--- a/.ci/kustomize/base/app-job.yaml
+++ b/.ci/kustomize/base/app-job.yaml
@@ -1,0 +1,11 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: app-job
+spec:
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      containers:
+        - name: es-populator
+          image: populatorImage

--- a/.ci/kustomize/base/kustomization.yaml
+++ b/.ci/kustomize/base/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - app-deployment.yaml
 - app-service.yaml
 - app-ingress.yaml
+- app-job.yaml
 - elasticsearch-deployment.yaml
 - elasticsearch-service.yaml


### PR DESCRIPTION
Moved database populator from initContainer to seperate k8s Job to allow for app to scale without purging Elastic search everytime.