### PR TITLE
Update dependencies for the Populator Docker image to avoid version conflicts

### DIFF
--- a/populator/requirements.txt
+++ b/populator/requirements.txt
@@ -7,7 +7,7 @@ html2text==2020.1.16
 idna==2.10
 importlib-metadata==2.0.0
 markdown==3.2.2
-requests==2.24.0
+requests==2.26.0
 soupsieve==2.0.1
-urllib3==1.26.5
+urllib3==1.26.6
 zipp==3.2.0


### PR DESCRIPTION
Dependabot helpfully updated the urllib3 version for the populator due to a security issue, but this caused version conflicts with the request package:

```
ERROR: Cannot install -r requirements.txt (line 10), -r requirements.txt (line 5) and urllib3==1.26.5 because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested urllib3==1.26.5
    elasticsearch 7.9.1 depends on urllib3>=1.21.1
    requests 2.24.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1
```

This bumps requests up to 2.26.0 to fix the issue.