### PR TITLE
Bumped spellcheck GitHub action to version 0.20.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Spellcheck
         if: env.scan_files != ''
-        uses: rojopolis/spellcheck-github-actions@0.10.0
+        uses: rojopolis/spellcheck-github-actions@0.20.0
         with:
           task_name: Markdown
           source_files: ${{ env.scan_files }}


### PR DESCRIPTION
I have recently released 0.20.0 of the spellcheck GitHub action, I can see that you are using 0.10.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, if you want a PR proposing a basic configuration, please let me know.