### PR TITLE
Explicitly allow GITHUB_TOKEN to write packages

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      issues: read
+      contents: read
     environment:
       name: UAT
       url: https://pr-${{ github.event.number }}.docsuat.devops.ukfast.co.uk


### PR DESCRIPTION
Explicitly grant permission to GITHUB_TOKEN to write packages to try and fix the issue we're seeing with PRs not being able to push containers up to ghcr.io for UAT.

Reference: https://docs.github.com/en/actions/security-guides/automatic-token-authentication