### PR TITLE
Switch to using a PAT for registry access

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PAT }}
 
       - name: Build and push app image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Using GITHUB_TOKEN doesn't seem to work like we need it to, to allow
forks to push their UAT images to the container registry. Switch to
using a username / personal access token instead. Both the username and
PAT are stored as secrets in the UAT environment.