### PR TITLE
Adjust workflow to run on target when labelled appropriately

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -2,15 +2,13 @@
 
 name: Build Docker images and deploy to UAT
 on:
-  pull_request:
+  pull_request_target:
     types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+      - labeled
 
 jobs:
   build_and_deploy:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy uat')
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -27,8 +25,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push app image
         uses: docker/build-push-action@v2

--- a/.github/workflows/destroy_uat.yml
+++ b/.github/workflows/destroy_uat.yml
@@ -3,12 +3,13 @@
 name: Teardown UAT environment for this PR
 on:
   workflow_dispatch: {}
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
 jobs:
   teardown:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy uat')
     runs-on: ubuntu-latest
     environment:
       name: UAT


### PR DESCRIPTION
Switching to using the [potentially dangerous](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) `pull_request_target` event instead of `pull_request`, so that secrets will be passed to forked repositories.

We use a label - `deploy uat` - to determine whether the workflow should run to avoid some of the dangers outlined in the above link. Labels can only be applied by people with write access to this repository, so any PRs should be inspected for malicious activity before the `deploy uat` label is added.

The `deploy uat` label must remain on the PR when the PR is closed in order to automatically teardown the UAT environment.

Attack surface is limited by the fact UAT deploys in it's own environment, external to any production system.