### PR TITLE
Use path context for building docker containers

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -18,6 +18,9 @@ jobs:
       name: UAT
       url: https://pr-${{ github.event.number }}.docsuat.devops.ukfast.co.uk
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v1
 
@@ -31,6 +34,7 @@ jobs:
       - name: Build and push app image
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ghcr.io/ukfast/docs-app:${{ github.event.number }}
           build-args: |
@@ -39,12 +43,10 @@ jobs:
       - name: Build and push populator image
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: ghcr.io/ukfast/docs-populator:${{ github.event.number }}
           file: populator/Dockerfile
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
 
       - name: Setup Kustomize
         uses: imranismail/setup-kustomize@v1


### PR DESCRIPTION
Since pull_request_target runs from the base repo and not the merge commit, it's not including the changes. We need to explicitly check the contents out and then pass the path context into the docker build action.

This is exactly what Github strongly recommend against, but we're gating it with a label.