### PR TITLE
Ensure container changes are rolled out, delete images on close

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -69,8 +69,9 @@ jobs:
       - name: Setup kubectl
         uses: azure/setup-kubectl@v1
 
-      - name: Create resources in Kubernetes
+      - name: Create/Update resources in Kubernetes
         run: |
           mkdir $HOME/.kube
           echo -e "${{ secrets.UAT_KUBECONFIG }}" > $HOME/.kube/config
           kubectl apply -f manifest.yaml
+          for d in $(kubectl -n docs-uat get deployments --no-headers -o custom-columns=":metadata.name" -l 'app.kubernetes.io/instance=docs-uat-${{ github.event.number }}'); do kubectl rollout restart deployments/$d; done;

--- a/.github/workflows/destroy_uat.yml
+++ b/.github/workflows/destroy_uat.yml
@@ -11,6 +11,8 @@ jobs:
   teardown:
     if: contains(github.event.pull_request.labels.*.name, 'deploy uat')
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     environment:
       name: UAT
     steps:
@@ -24,3 +26,19 @@ jobs:
           kubectl -n docs-uat delete ingresses -l 'app.kubernetes.io/instance=docs-uat-${{ github.event.number }}'
           kubectl -n docs-uat delete services -l 'app.kubernetes.io/instance=docs-uat-${{ github.event.number }}'
           kubectl -n docs-uat delete deployments -l 'app.kubernetes.io/instance=docs-uat-${{ github.event.number }}'
+
+      - name: Remove the app container image from the registry
+        uses: bots-house/ghcr-delete-image-action@v1.0.0
+        with:
+          owner: ukfast
+          name: docs-app
+          tag: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove the populator container image from the registry
+        uses: bots-house/ghcr-delete-image-action@v1.0.0
+        with:
+          owner: ukfast
+          name: docs-populator
+          tag: ${{ github.event.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ensure that container changes are rolled out after application - repeated UAT deploys weren't pulling containers, needed to rollout restart. Doing this unconditionally on every deployment for ease.

When a PR is closed, the container images created for the PR will now be removed from ghcr.io.