### PR TITLE
Add instructions on how to get certs without using the cli.ini file

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -28,6 +28,7 @@ ARPA
 ASA
 ASDM
 authenticator
+authenticators
 autodiscover
 AutoSSL
 AWStats

--- a/source/domains/safedns/certbotplugin.md
+++ b/source/domains/safedns/certbotplugin.md
@@ -117,6 +117,20 @@ IMPORTANT NOTES:
   -d server3.ukfast.co.uk
 ```
 
+## Without using the `cli.ini` file
+
+If you prefer to not use the `cli.ini` file, perhaps because you need to use different authenticators side by side, you can be more verbose on the command line and specify the options like this:
+
+```bash
+/usr/local/bin/certbot certonly \
+  -d server1.ukfast.co.uk \
+  -d *.ukfast.dev \
+  -d server3.ukfast.co.uk \
+  --authenticator dns_safedns \
+  --dns_safedns-credentials /root/.config/letsencrypt/dns_safedns.ini \
+  --deploy-hook "/usr/bin/systemctl restart httpd"
+```
+
 ## Known issues
 
 If you get any Python cryptography errors, such as:


### PR DESCRIPTION
Adding an example of using the options from the `cli.ini` file on the command line