### PR TITLE
Update Elasticsearch to v7.16.2

### DIFF
--- a/.ci/kustomize/base/elasticsearch-deployment.yaml
+++ b/.ci/kustomize/base/elasticsearch-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       imagePullSecrets:
       - name: gitlab-registry-auth
       containers:
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
         name: elasticsearch
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This fixes CVEs related to log4j and others
* https://www.elastic.co/blog/new-elasticsearch-and-logstash-releases-upgrade-apache-log4j2